### PR TITLE
Data Aggregator Boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ box.exe
 *.secret
 .env
 *.log
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+*.csv
+box.exe
+*.secret
+.env
+*.log

--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ This application depends on a data aggregator that runs once a day.
 
 The current implementation involves running `schedule_aggregator.cfm` to start the scheduled task, and that will schedule `data_aggregator.cfm` to be ran once a day.
 
-
-From there we will need to set up the Datasource, which tells Lucee how to connect to the database.
-
 To run `schedule_aggregator`, you'll need to open it from the directory viewer that opens with the server.
 
 You may also use Lucee > Open > Site Home > schedule_aggregator.cfm

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
 # RDE-covid-resource-guide
+
+## Setup
+### Setting up Lucee with Commandbox.
+Download Commandbox from here https://www.ortussolutions.com/products/commandbox
+
+1. On windows, add CommandBox to the environment variables.
+
+1. In this directory, run `box server start` to start the Lucee server.
+
+This will open the directory viewer in your web browser. Any CFML files in this directory can will be ran using Lucee.
+
+Note that, if you open the box CLI with `box`, you can omit the "box" from any of its commands.
+
+### Setting up DataSource for MS SQL
+1. Run `box install commandbox-cfconfig` to install cfconfig.
+
+1. Run `box cfconfig set AdminPassword=NEW_PASSWORD`
+where NEW_PASSWORD is replaced with a password of your choice.
+
+  This will allow you to access the Lucee admin panel, which can be accessed by going to your system tray.
+
+1. Restart the Lucee server if it's still running, either by running `box server restart` or by right clicking the Lucee icon and clicking "Restart Server".
+
+1. Right click the Lucee icon in the system tray, and click Open > Server Admin.
+
+1. Enter your password to access the admin panel.
+
+  Note - If the password is not set, you won't be able to access the Admin panel.
+
+1. Click Datasource
+
+ - Type covid_database as the name of the datasource, and Microsoft SQL Server as the Type.
+
+ - Fill out fields using the Datasource_credentials.secret file.
+
+ This will add the Microsoft SQL Database to the datasources usable in the CFML code.
+
+ You can run `test_database.cfm` to verify the connection.
+
+## Scheduling the Data Aggregator
+
+This application depends on a data aggregator that runs once a day.
+
+The current implementation involves running `schedule_aggregator.cfm` to start the scheduled task, and that will schedule `data_aggregator.cfm` to be ran once a day.
+
+
+From there we will need to set up the Datasource, which tells Lucee how to connect to the database.
+
+To run `schedule_aggregator`, you'll need to open it from the directory viewer that opens with the server.
+
+You may also use Lucee > Open > Site Home > schedule_aggregator.cfm
+
+This window will show all scripts previously scheduled to run, followed by scripts that are now scheduled to run. The data aggregator should be on this list.

--- a/data_aggregator.cfm
+++ b/data_aggregator.cfm
@@ -31,8 +31,11 @@ function fetch_covid_data(){
 
 
 function fetch_vaccine_data(){
+  // Fetches json file containing yesterday's Vaccine data by county for NJ/NY/CT
   fileURL = "https://data.cdc.gov/resource/8xkx-amqh.json?";
-  fileURL &= "$where=recip_state in('NJ', 'NY', 'CT')"
+  fileURL &= "$where=recip_state in('NJ', 'NY', 'CT')";
+  yesterday = DateAdd('d',-1,Now())
+  fileURL &= "&date=" & dateTimeFormat(yesterday, "yyyy-MM-dd");
   cfhttp(url=fileURL, method="GET", file="8xkx-amqh.json");
 }
 

--- a/data_aggregator.cfm
+++ b/data_aggregator.cfm
@@ -1,14 +1,39 @@
 <cfscript>
 run_aggregator();
 function run_aggregator(){
-  cffile(action="write", file="last_ran_aggregator.log" output=#Now()#);
+  // Main Aggregator Script, this gets called daily.
+  ONCE_A_DAY = true;
+  if(days_since_update() < 1 AND ONCE_A_DAY){
+    cfdump(var="Aggregator already ran today!");
+    return;
+  }
+  cfdump(var="Running Aggregator...");
+  cffile(action="write", file="last_ran_aggregator.log" output=#dateTimeFormat(now(), "yyyy.MM.dd HH:nn:ss ") #);
   fetch_covid_data();
+  fetch_vaccine_data();
   // More aggregation scripts here
 }
+
+function days_since_update(){
+  cffile(action="read", file="last_ran_aggregator.log", variable="last_ran_string");
+  last_ran_datetime = parseDateTime(last_ran_string);
+  days_since_update = DateDiff("d", last_ran_datetime, now());
+  cfdump(var="Days since last update: " & days_since_update);
+  return days_since_update
+}
+
+
 function fetch_covid_data(){
   // Fetches csv file containing today's Covid Cases/Deaths by county.
   fileURL = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/live/us-counties.csv";
   cfhttp(url=fileURL, method="GET", file="us-counties.csv");
+}
+
+
+function fetch_vaccine_data(){
+  fileURL = "https://data.cdc.gov/resource/8xkx-amqh.json?";
+  fileURL &= "$where=recip_state in('NJ', 'NY', 'CT')"
+  cfhttp(url=fileURL, method="GET", file="8xkx-amqh.json");
 }
 
 </cfscript>

--- a/data_aggregator.cfm
+++ b/data_aggregator.cfm
@@ -1,0 +1,14 @@
+<cfscript>
+run_aggregator();
+function run_aggregator(){
+  cffile(action="write", file="last_ran_aggregator.log" output=#Now()#);
+  fetch_covid_data();
+  // More aggregation scripts here
+}
+function fetch_covid_data(){
+  // Fetches csv file containing today's Covid Cases/Deaths by county.
+  fileURL = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/live/us-counties.csv";
+  cfhttp(url=fileURL, method="GET", file="us-counties.csv");
+}
+
+</cfscript>

--- a/schedule_aggregator.cfm
+++ b/schedule_aggregator.cfm
@@ -1,0 +1,21 @@
+<!-- List all previously scheduled tasks -->
+<cfschedule action="list" result="res">
+<cfdump var=#res#>
+
+<!-- Schedule Data Aggregator to run every midnight -->
+ <cfschedule
+  action="update"
+  task="Data Aggregator"
+  operation="HTTPRequest"
+  startDate="10/10/2021"
+  startTime="12:00 AM"
+  url="http://127.0.0.1:64493/data_aggregator.cfm"
+  interval="daily" />
+
+
+  <!-- List all currently scheduled tasks -->
+<cfschedule
+  action="list"
+  result="res"
+>
+<cfdump var=#res#>

--- a/schedule_aggregator.cfm
+++ b/schedule_aggregator.cfm
@@ -14,8 +14,5 @@
 
 
   <!-- List all currently scheduled tasks -->
-<cfschedule
-  action="list"
-  result="res"
->
+<cfschedule action="list" result="res">
 <cfdump var=#res#>

--- a/test_database.cfm
+++ b/test_database.cfm
@@ -1,0 +1,8 @@
+<cfscript>
+// Using function so var can be used
+test_database();
+function test_database(){
+  var qry = queryExecute( sql='SELECT @@version;', options={ datasource : "covid_database" } );
+  cfdump(var = qry);
+}
+</cfscript>


### PR DESCRIPTION
Here we have the boilerplate code for the data aggregator. 
It includes:
* A README for how to set up CommandBox, Lucee, connecting to the database, and running the Aggregator
* More .gitignore
* data_aggregator.cfm - The aggregator itself, which will be run daily at midnight
* schedule_aggregator.cfm - A script to schedule the aggregator task on the server
* test_database.cfm - A script to verify connection to our database

At the moment most of my working code for the data aggregation is on a .cfc file, which I will move onto the new one in a future PR.
For now we can add additional functionality to the aggregator by calling more functions in run_aggregator().

Also I haven't been able to test this on AWS yet, so we may need to change some details like hostname or port to get it to work.

Edit: Oct 19
Aggregator now restricts calls to once a day, which can be toggled with a boolean near the top of the file.
Aggregator now downloads CDC vaccination data in addition to the covid data, and it only gets the data in our tri-state area for yesterday. 