### PR TITLE
Aggregated full COVID dataset

### DIFF
--- a/covid_db_calculations.sql
+++ b/covid_db_calculations.sql
@@ -1,0 +1,50 @@
+UPDATE covid_data SET total_cases = (
+  SELECT SUM(daily_cases)
+  FROM covid_data previous_data
+  WHERE previous_data.fips = covid_data.fips
+  AND previous_data.date <= covid_data.date
+);
+
+UPDATE covid_data SET total_deaths = (
+  SELECT SUM(daily_deaths)
+  FROM covid_data previous_data
+  WHERE previous_data.fips = covid_data.fips
+  AND previous_data.date <= covid_data.date
+);
+
+UPDATE covid_data SET total_recoveries = (
+  ISNULL(
+    (
+      SELECT SUM(total_cases)
+      FROM covid_data old_data
+      WHERE old_data.fips = covid_data.fips
+      AND old_data.date = DATEADD(DAY, -14, covid_data.date)
+    ) -
+    (
+      SELECT SUM(total_deaths)
+      FROM covid_data today_data
+      WHERE today_data.fips = covid_data.fips
+      AND today_data.date = covid_data.date
+    )
+  , 0)
+);
+
+UPDATE covid_data SET total_recoveries = 0
+WHERE total_recoveries < 0;
+
+UPDATE covid_data SET daily_recoveries = (
+  ISNULL(
+    (
+      SELECT SUM(total_recoveries)
+      FROM covid_data today_data
+      WHERE today_data.fips = covid_data.fips
+      AND today_data.date = covid_data.date
+    ) -
+    (
+      SELECT SUM(total_recoveries)
+      FROM covid_data yesterday_data
+      WHERE yesterday_data.fips = covid_data.fips
+      AND yesterday_data.date = DATEADD(DAY, -1, covid_data.date)
+    )
+  , 0)
+);

--- a/data_aggregator.cfm
+++ b/data_aggregator.cfm
@@ -5,16 +5,20 @@ function run_aggregator(){
   ONCE_A_DAY = true;
   if(days_since_update() < 1 AND ONCE_A_DAY){
     cfdump(var="Aggregator already ran today!");
+    show_covid_data();
     return;
   }
   cfdump(var="Running Aggregator...");
   cffile(action="write", file="last_ran_aggregator.log" output=#dateTimeFormat(now(), "yyyy.MM.dd HH:nn:ss ") #);
   fetch_covid_data();
+  insert_covid_data();
+  calculate_covid_stats();
   fetch_vaccine_data();
   // More aggregation scripts here
 }
 
 function days_since_update(){
+  // Returns number of days since the aggregator has run.
   cffile(action="read", file="last_ran_aggregator.log", variable="last_ran_string");
   last_ran_datetime = parseDateTime(last_ran_string);
   days_since_update = DateDiff("d", last_ran_datetime, now());
@@ -25,8 +29,89 @@ function days_since_update(){
 
 function fetch_covid_data(){
   // Fetches csv file containing today's Covid Cases/Deaths by county.
-  fileURL = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/live/us-counties.csv";
-  cfhttp(url=fileURL, method="GET", file="us-counties.csv");
+  // Sourced from NYTimes' GitHub repo.
+  fileURL = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv";
+  cfhttp(url=fileURL, method="GET", file="us-counties(all).csv");
+}
+
+function update_county_data(){
+  // Takes counties from county_data.csv and uploads to DB
+  // Only called once to ready the DB.
+  county_data_file = FileOpen("county_data.csv", "read");
+  values = []
+  while (NOT FileisEOF(county_data_file)){
+    line = FileReadLine(county_data_file);
+    line_data = listToArray(line, ',');
+    //cfdump(var=line_data);
+    fips = line_data[1];
+    county = line_data[2];
+    state = line_data[3];
+    population = line_data[4]
+    // Don't forget quotation marks on strings! Not passed over like Python.
+    value = "(#fips#, '#county#', '#state#', '#population#')";
+    values.Append(value);
+  }
+
+  writeOutput("<br>Writing counties to DB:");
+  sql_query = "INSERT INTO counties (fips, county_name, state, population) VALUES " & list
+  myQuery = queryExecute(sql=sql_query, options={datasource="covid_database"});
+  cfdump(var=myQuery);
+}
+
+function show_covid_data(){
+  // Dumps a readable version of the table.
+  // Can't seem to use LIMIT on this, so it'll be 9999 rows.
+  WriteOutput("Current Table: <br>")
+  sql_query = "SELECT * FROM covid_data"
+  myQuery = queryExecute(sql=sql_query, options={datasource="covid_database"});
+  cfdump(var=myQuery);
+}
+
+function insert_covid_data(){
+  // Uses data from NYTimes' Repo "us-counties.csv"
+  // Inserts rows into DB with cases, deaths
+  // Table is currently configured to ignore duplicate values
+  covid_data_file = FileOpen("us-counties(all).csv", "read");
+  values = []
+  while (NOT FileisEOF(covid_data_file)){
+    line = FileReadLine(covid_data_file);
+    line_data = listToArray(line, ',', true);
+    state = line_data[3];
+    fips = line_data[4];
+    date = line_data[1];
+    cases = line_data[5];
+    deaths = line_data[6];
+
+    in_target_area = arrayContains(["New Jersey", "New York", "Connecticut"], state);
+    if (in_target_area AND fips != ""){
+      value = "(#fips#, '#date#', '#cases#', '#deaths#')";
+      values.Append(value);
+    }
+
+    if(ArrayLen(values) == 999 OR FileisEOF(covid_data_file)){
+      // Send it up
+      // item,item,item as a string
+      list = values.ToList();
+      sql_query = "INSERT INTO covid_data (fips, date, daily_cases, daily_deaths) VALUES " & list
+      WriteOutput("Inserting this many rows:");
+      cfdump(var=ArrayLen(values))
+      myQuery = queryExecute(sql=sql_query, options={datasource="covid_database"});
+      values = [];
+      list = [];
+    }
+  }
+
+  // Entire file sent to DB
+  FileClose(covid_data_file);
+}
+
+function calculate_covid_stats(){
+  // Perform Calculations on covid_data table, After cases/deaths are stored.
+  // Computes sum_cases, sum_deaths, sum_recoveries, and recoveries.
+  // Takes A LONG TIME to run (Several minutes), needs optimization in the future.
+  sql_query = FileRead("covid_db_calculations.sql");
+  myQuery = queryExecute(sql=sql_query, options={datasource="covid_database"});
+  show_covid_data();
 }
 
 


### PR DESCRIPTION
# Summary
This PR encapsulates everything from downloading the entire county-level dataset for covid stats, to calculating new information such as totals and recoveries.

This PR should fully close #4 

**IMPORTANT: If anyone wants to test their own code in the data aggregator, I'd strongly recommend commenting the covid data functions in the `run_aggregator()` function, as they now use the FULL dataset and should not be called frequently in testing.**

# Methodology
The process used in the covid_data calculation is:

- Download the full (>10,000 rows) county-level covid data csv file from the NYTimes repo
- Filter for target states and extract desired stats
- Insert values (fips, date, cases, deaths) into database (At most 999 at a time)
- Update the rows of the database to calculate
  - total_cases
  - total_deaths
  - total_recoveries
  - recoveries

It's also notable that I changed the table to ignore duplicate inserts while making these changes, but are not in the code since it is a 1-time permanent change to the database.

# Future Optimizations
The update query can take quite a while, so it would be advisable to make optimizations to that query once the rest of the objectives are complete.
Since the aggregator only runs once a day, this runtime should be fine, just don't run it during testing.

Another optimization that could be done, is the aggregator could download and process the NYTimes' live csv data that only holds the last day of updates, if the aggregator has been called exactly 1 day ago.
This would save time in downloading the csv file, and parsing/inserting the data. However, the update query would run through the entire table.