### PR TITLE
Aggregator fixes

### DIFF
--- a/CovidData.cfc
+++ b/CovidData.cfc
@@ -53,6 +53,7 @@ component restpath="/CovidData"  rest="true" {
 
         county_list.append(county_data)
       }
+      FileClose(county_data_file);
     //dict = {county_list=county_list}
     returnVal = SerializeJSON(county_list);
 

--- a/covid-resource-guide/src/screens/CovidDataTable.jsx
+++ b/covid-resource-guide/src/screens/CovidDataTable.jsx
@@ -26,25 +26,39 @@ function CovidDataTable(props) {
   const [countyDataList, setCountyDataList] = useState([]);
   const [countyMap, setCountyMap] = useState({});
 
+  function pad_with_zeroes(number, length) {
+
+    var my_string = '' + number;
+    while (my_string.length < length) {
+        my_string = '0' + my_string;
+    }
+
+    return my_string;
+
+}
+
   function getCounty(fips){
+    fips = fips.trim()
+    fips = fips.padStart(5, "0");
+    // console.log(new_fips)
     if (countyMap[fips]){
       return countyMap[fips];
     }else{
+      // console.log(new_fips)
       return "SKIP";
     }
   }
 
   function getRow(row){
-    if (true){
-      return(
-        <tr key={row[0]}>
-          <td>{getCounty(row[0])}</td>
-          <td>{row[1]}</td>
-          <td>{row[2]}</td>
-          <td>{row[3]}</td>
-        </tr>
-      );
-    }
+    return(
+      <tr key={row[0]}>
+        <td>{getCounty(row[0])}</td>
+        <td>{row[1]}</td>
+        <td>{row[2]}</td>
+        <td>{row[3]}</td>
+      </tr>
+    );
+
   }
 
   function getTable(rows, countyMap){
@@ -100,7 +114,7 @@ function CovidDataTable(props) {
   useEffect(() => {
     // Run when we have countyDataList
     let tempCountyMap = {};
-    for (let i = 0; i < countyDataList.length - 1; i++){
+    for (let i = 0; i < countyDataList.length; i++){
       let countyData = countyDataList[i];
       let fips = countyData.FIPS;
       let countyName = countyData.COUNTY;


### PR DESCRIPTION
This PR fixes a couple of things about the data aggregator
- It now automatically populates the county table in case it's dropped or w/e
- It now fetches ONLY counties in the tri-state area, not all counties in NJ/NY/CT
- It now takes about 6 minutes rather than 20-25 to run
- Now passes NYC stats to the 5 counties inside of it. The NYTimes dataset combines these 5 counties into one entry named "New York City" and omits a fips code. 

The Table in the charts page also now correctly displays all available counties, including those from CT and PA.

Closes #25